### PR TITLE
Upgrade to NixOS 21.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hardkernel NixOS for ODROID HC4
 
-This is an unofficial installation configuration of [NixOS 20.09](https://nixos.org/manual/nixos/stable/) for the [Hardkernel ODROID
+This is an unofficial installation configuration of [NixOS 21.05](https://nixos.org/manual/nixos/stable/) for the [Hardkernel ODROID
 HC4](https://wiki.odroid.com/odroid-hc4/odroid-hc4) microcomputer.
 
 To build an image that can be flashed to an SD card, run:

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -50,9 +50,8 @@
   ];
 
   # Include support for various filesystems.
-  # cifs fails when cross-compiling due to its dependency talloc failing to compile
   # zfs fails when cross-compiling due to not being able to build kernel module
-  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" ];
+  boot.supportedFilesystems = [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
 
   # Configure host id for ZFS to work
   networking.hostId = lib.mkDefault "8425e349";

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -33,7 +33,7 @@
     # Hardware-related tools.
     pkgs.sdparm
     pkgs.hdparm
-    # pkgs.smartmontools # for diagnosing hard disks
+    pkgs.smartmontools # for diagnosing hard disks
     pkgs.pciutils
     pkgs.usbutils
 

--- a/modules/installation-device.nix
+++ b/modules/installation-device.nix
@@ -69,5 +69,13 @@ with lib;
     # because we have the firewall enabled. This makes installs from the
     # console less cumbersome if the machine has a public IP.
     networking.firewall.logRefusedConnections = mkDefault false;
+
+    # Prevent installation media from evacuating persistent storage, as their
+    # var directory is not persistent and it would thus result in deletion of
+    # those entries.
+    environment.etc."systemd/pstore.conf".text = ''
+      [PStore]
+      Unlink=no
+    '';
   };
 }

--- a/modules/nixpkgs/cross-compilation.nix
+++ b/modules/nixpkgs/cross-compilation.nix
@@ -5,20 +5,6 @@ let
     inherit src;
     name = "nixpkgs-patched";
     patches = [
-      # Disable gobject-introspection during cross-compilation
-      (pkgs.fetchpatch {
-        url = "https://patch-diff.githubusercontent.com/raw/NixOS/nixpkgs/pull/108173.patch";
-        sha256 = "0hx4xznqb8cx7c87lirlwbj4n7wzgvhv0zkldhxvi60xzw3mkcch";
-      })
-      # Patch mailutils (dependency of zfs) for cross-compilation
-      (pkgs.fetchpatch {
-        url = "https://github.com/NixOS/nixpkgs/commit/a4c39a624c9658beb96c95fa7947aed988ed7c59.patch";
-        sha256 = "1cf30vhw5zrigdpz85k02h3vx826wxlrjqk775jja35gf3wbzxh9";
-      })
-      (pkgs.fetchpatch {
-        url = "https://github.com/NixOS/nixpkgs/commit/f7ec01ab6c91b30cc1df54cd49151e401b3fdcb0.patch";
-        sha256 = "06igyijq4b1jg883k3p9w0fl8z55m73v7r7zdkdbj9sddl4i4q6d";
-      })
     ];
   };
 in

--- a/modules/nixpkgs/default.nix
+++ b/modules/nixpkgs/default.nix
@@ -1,4 +1,4 @@
 builtins.fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/352481146d87aa2d277ea696657aa7db5378b90f.tar.gz";
-  sha256 = "0fyi26dcpprbh0zccwjjp6spikbbj8dsal2aa8h1qnw41a4fjjxm";
+  url = "https://github.com/NixOS/nixpkgs/archive/382039c05a16827a7f0731183e862366b66b422f.tar.gz";
+  sha256 = "08mvanp4400zfz1knyxsjhkc7ryjlaa9awcg763ghj235wk6mlld";
 }

--- a/modules/odroidhc4/default.nix
+++ b/modules/odroidhc4/default.nix
@@ -38,16 +38,6 @@ with lib;
   # set a default root password
   users.users.root.initialPassword = "toor";
 
-  # Install cachix binary cache for faster installations
-  nix = {
-    binaryCaches = [
-      "https://considerate.cachix.org"
-    ];
-    binaryCachePublicKeys = [
-      "considerate.cachix.org-1:qI1u8kAd+aovY5qxCgby2OJhfp7ZMVwCt6JyT2V6rfM="
-    ];
-  };
-
   fileSystems = {
     "/boot" = {
       device = "/dev/disk/by-label/FIRMWARE";

--- a/modules/odroidhc4/default.nix
+++ b/modules/odroidhc4/default.nix
@@ -9,7 +9,7 @@ with lib;
   # torvalds/linux
   boot.kernelPackages = pkgs.linuxPackagesFor pkgs.linux_hardkernel;
 
-  boot.initrd.availableKernelModules = [ ];
+  boot.initrd.availableKernelModules = mkForce [ ];
 
   nixpkgs.overlays = [
     (import ../kernel/overlay.nix)

--- a/modules/sd-image/default.nix
+++ b/modules/sd-image/default.nix
@@ -4,22 +4,13 @@ let
 in
 {
   imports = [
-    "${nixpkgs}/nixos/modules/installer/cd-dvd/sd-image.nix"
+    "${nixpkgs}/nixos/modules/installer/sd-card/sd-image.nix"
     ../installation-device.nix
     ../odroidhc4
   ];
 
   # set cross compiling
-  nixpkgs.crossSystem = {
-    config = "aarch64-unknown-linux-gnu";
-    platform = lib.systems.examples.aarch64-multiplatform.platform // {
-      kernelTarget = "Image.gz";
-      gcc = {
-        arch = "armv8-a";
-        extraArgs = [ "-mcrc" "-mcrypto" ];
-      };
-    };
-  };
+  nixpkgs.crossSystem.config = "aarch64-unknown-linux-gnu";
 
   # Use pinned packages
   nixpkgs.pkgs = import "${nixpkgs}" {

--- a/modules/uboot/boot-ini-builder.sh
+++ b/modules/uboot/boot-ini-builder.sh
@@ -115,7 +115,7 @@ cat >$tmpFile <<EOF
 ODROIDC4-UBOOT-CONFIG
 # Generated file, all changes will be lost on nixos-rebuild!
 
-setenv bootlabel "Hardkernel NixOS 20.09"
+setenv bootlabel "Hardkernel NixOS 21.05"
 
 setenv board "odroidc4"
 setenv display_autodetect "true"

--- a/modules/uboot/hardkernel-firmware.nix
+++ b/modules/uboot/hardkernel-firmware.nix
@@ -65,7 +65,7 @@ in
     src = fetchgit {
       url = "https://github.com/hardkernel/u-boot.git";
       rev = "90ebb7015c1bfbbf120b2b94273977f558a5da46"; # "odroidg12-v2015.01"
-      sha256 = "sha256-2yOiwz69LKNUp0ZzTsg4w1cfeEZ3xEelhTXhpMT8qRk=";
+      sha256 = "0jcr3pfl322fkqs7anqjhqwbqn7han0phi04r36ks8hsi53qrlyi";
       leaveDotGit = true;
     };
 


### PR DESCRIPTION
This pull request upgrades NixOS from 20.09 to 21.05 (last stable).

Some notes:

- No patch of nixpkgs is required anymore to cross-compile. For now I am following the old structure of this Nix project, but we could drop `modules/nixpkgs/cross-compilation.nix`.
- NixOS 21.05 includes an aarch64 build cache so I disable the custom cachix build cache.
- I add `smartmontools` and `cifs` because now they compile fine and they are defaults in NixOS sd-card images.
- I use `boot.initrd.availableKernelModules = lib.mkForce [ ]` as it is no longer empty since NixOS 21.05: https://github.com/NixOS/nixpkgs/blob/nixos-21.05/nixos/modules/installer/sd-card/sd-image.nix#L32