### PR TITLE
Various small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ To build an image that can be flashed to an SD card, run:
 $ nix-build
 ```
 
-However, you might want to add your own SSH keys to the [odroidhc4 configuration](./modules/odroidhc4/default.nix)
-before doing so.
+However, you might want to add your own SSH keys to the [configuration](./configuration.nix) before doing so.
 
 To flash the created image run
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,9 +1,15 @@
-{ pkgs, lib, config, ... }:
+{ pkgs, lib, config, modulesPath, ... }:
 let
+  # Change this
+  sshAuthorizedKeys = [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiRIiaJvpr2JtisMaTN7QhYENBUQ9r/WzthEuMcAXNetCHbP5Ug74j3YA4DcI3ajhenqc3BGQPP0lh2AHZ0uriFqkxMCezSfu0+gSygzUUZh2lJfEnnPuv9J6BKWEtu1cr/pZQpfyye5RfgjuYe+v3aY14InDT0LW/UMR32EPK9yhuG0s+gkMRuqfF8HCUEgA6xDzg67CY9KfCu2JuekCHJJzdTSERkEkejUCd3cnlV63eUdo+SDrFdfsOR5CIpKPq27TpRAvqTvjuILLlG8mc1O/EUdf8P13Y3SF1itiTGBMCnmN/X9hZfzKL4x8skhqWg6sD2p+O8lbmfdI1FV0Gc6RZvHXJHJjXHIVAu1OSqduOMlPVNPfxTfXQh6VTexPAiPR77EJt2X2b6bL4HvgZxTNPh0cZTbpPcbDRmk8AuHfV6cDWNFjMIDytLeleL68g1cedWM1wNnJh4sy76CvY61QKvoNpcl+d8xwDDDDSPPhSGE8MXwEXgqsnrZTqoKc= considerate@considerate-nixos"
+  ];
+
   nixpkgs = import ./nixpkgs;
 in
 {
   imports = [
+    "${modulesPath}/profiles/base.nix"
     ./modules/odroidhc4
   ];
   # Pin nixpkgs version for better reproducibility
@@ -12,4 +18,18 @@ in
     # specified here, hence we leave it out.
     inherit (config.nixpkgs) config localSystem crossSystem;
   });
+
+  # SSH
+  services.openssh.enable = true;
+  services.openssh.permitRootLogin = "yes";
+
+  # Add public SSH key to root user's authorized_keys file
+  users.users.root.openssh.authorizedKeys.keys = sshAuthorizedKeys;
+
+  # DNS
+  services.resolved.enable = true;
+  services.resolved.dnssec = "false";
+
+  # set a default root password
+  users.users.root.initialPassword = "toor";
 }

--- a/default.nix
+++ b/default.nix
@@ -6,16 +6,12 @@ let
   nixos = import "${nixpkgs}/nixos" {
     configuration = { config, ... }: {
       imports = [
+        ./configuration.nix
         ./modules/sd-image
       ];
 
       # set cross compiling
       nixpkgs.crossSystem.config = "aarch64-unknown-linux-gnu";
-
-      # Use pinned packages
-      nixpkgs.pkgs = import "${nixpkgs}" {
-        inherit (config.nixpkgs) config localSystem crossSystem;
-      };
     };
   };
 in

--- a/modules/odroidhc4/default.nix
+++ b/modules/odroidhc4/default.nix
@@ -2,7 +2,6 @@
 with lib;
 {
   imports = [
-    "${modulesPath}/profiles/base.nix"
     ../uboot/hardkernel-uboot.nix
   ];
   # The linux kernel used is compiled from the Hardkernel fork of
@@ -27,23 +26,6 @@ with lib;
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = false;
   boot.loader.hardkernel-uboot.enable = true;
-
-
-  # SSH
-  services.openssh.enable = true;
-  services.openssh.permitRootLogin = "yes";
-
-  # Add public SSH key to root user's authorized_keys file
-  users.users.root.openssh.authorizedKeys.keys = [
-    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDiRIiaJvpr2JtisMaTN7QhYENBUQ9r/WzthEuMcAXNetCHbP5Ug74j3YA4DcI3ajhenqc3BGQPP0lh2AHZ0uriFqkxMCezSfu0+gSygzUUZh2lJfEnnPuv9J6BKWEtu1cr/pZQpfyye5RfgjuYe+v3aY14InDT0LW/UMR32EPK9yhuG0s+gkMRuqfF8HCUEgA6xDzg67CY9KfCu2JuekCHJJzdTSERkEkejUCd3cnlV63eUdo+SDrFdfsOR5CIpKPq27TpRAvqTvjuILLlG8mc1O/EUdf8P13Y3SF1itiTGBMCnmN/X9hZfzKL4x8skhqWg6sD2p+O8lbmfdI1FV0Gc6RZvHXJHJjXHIVAu1OSqduOMlPVNPfxTfXQh6VTexPAiPR77EJt2X2b6bL4HvgZxTNPh0cZTbpPcbDRmk8AuHfV6cDWNFjMIDytLeleL68g1cedWM1wNnJh4sy76CvY61QKvoNpcl+d8xwDDDDSPPhSGE8MXwEXgqsnrZTqoKc= considerate@considerate-nixos"
-  ];
-
-  # DNS
-  services.resolved.enable = true;
-  services.resolved.dnssec = "false";
-
-  # set a default root password
-  users.users.root.initialPassword = "toor";
 
   fileSystems = {
     "/boot" = {

--- a/modules/odroidhc4/default.nix
+++ b/modules/odroidhc4/default.nix
@@ -11,6 +11,10 @@ with lib;
 
   boot.initrd.availableKernelModules = mkForce [ ];
 
+  # Remove zfs from supported filesystems as it fails due to not being able to
+  # build the kernel module
+  boot.supportedFilesystems = lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
+
   # We do know the hardware we are planning to deploy to
   hardware.enableRedistributableFirmware = mkForce false;
 

--- a/modules/sd-image/default.nix
+++ b/modules/sd-image/default.nix
@@ -37,8 +37,8 @@
     # and create a mount point for the FIRMWARE partition at /boot
     populateRootCommands = ''
       mkdir -p ./files/boot ./files/etc/nixos
-      cp ${../../configuration.nix} ./files/etc/nixos/configuration.nix
-      cp -r ${../.} ./files/etc/nixos/modules
+      cp -r --target-directory=./files/etc/nixos ${lib.cleanSource ../..}/*
+      chmod -R u+w ./files/etc/nixos
     '';
   };
 }

--- a/modules/sd-image/default.nix
+++ b/modules/sd-image/default.nix
@@ -16,10 +16,6 @@
     })
   ];
 
-  # Remove zfs from supported filesystems as it fails when cross-compiling due
-  # to not being able to build kernel module
-  boot.supportedFilesystems = lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
-
   sdImage = {
     compressImage = false;
     # Use 512 MB for boot partition to fit multiple kernel versions


### PR DESCRIPTION
This pull request combines a few small improvements. Let me know if you'd rather have one PR per logical grouping.

Changes:

* Adds .gitignore to ignore the output of nix-build
* Uses the odroidhc4 module for hardware specific settings and configuration.nix for everything specific to the image (and also includes configuration.nix for the sd-image image)
* Makes sure the whole repo content minus version history is copied to etc/nixos on the image so nixos-rebuild works without modifications
* Also disable ZFS on native builds, since for me that was failing not just for cross-compilation

I've tested:

* bootup
* serial output
* network + SSH
* SATA (only one port tested)
* `nixos-rebuild boot` (didn't modify the system beforehand other than adding some generous swap and TMPDIR on a SATA SSD) -> rebuilt system boots fine

I did not test HDMI output or USB, but these changes are unlikely to break those.